### PR TITLE
remove Debugger for Chrome''Extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,8 +6,7 @@
     "recommendations": [
         "ionide.ionide-fsharp",
         "ms-dotnettools.csharp",
-        "editorconfig.editorconfig",
-        "msjsdiag.debugger-for-chrome"
+        "editorconfig.editorconfig"      
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": [


### PR DESCRIPTION
the extension is deprecated, 
see https://github.com/Microsoft/vscode-chrome-debug